### PR TITLE
Use class instead of functions for code reuse, fix case on js

### DIFF
--- a/ScratchBlocks.php
+++ b/ScratchBlocks.php
@@ -17,51 +17,20 @@ if (!defined('MEDIAWIKI')) {
     die();
 }
 
+require_once __DIR__ . "/ScratchblockHooks.php";
 
 // Hooks
 
-$wgExtensionFunctions[] = 'sbSetup';
-$wgHooks['ParserFirstCallInit'][] = 'sbParserInit';
- 
-
-// Hook callback function into parser
-
-function sbParserInit (Parser $parser) {
-    // Register <scratchblocks> and <sb> tag
-    $parser->setHook('scratchblocks', 'sbRenderTag');
-	$parser->setHook('sb', 'sbRenderInlineTag');
-    return true;
-}
- 
-
-// Ouput HTML for <scratchblocks> tag
-
-function sbRenderTag ($input, array $args, Parser $parser, PPFrame $frame) {
-    return '<pre class="blocks">' . htmlspecialchars($input) . '</pre>';
-}
-
-// Output HTML for inline <sb> tag
-
-function sbRenderInlineTag ($input, array $args, Parser $parser, PPFrame $frame) {
-	//throw new Exception("what");
-    return '<code class="blocks">' . htmlspecialchars($input) . '</code>';
-}
-
-
-// Make wiki load resources
-
-function sbSetup () {
-    global $wgOut;
-    $wgOut->addModules('ext.scratchBlocks');
-}
+$wgExtensionFunctions[] = 'ScratchblockHook::sbSetup';
+$wgHooks['ParserFirstCallInit'][] = 'ScratchblockHook::sbParserInit';
 
 
 // Define resources
 
 $wgResourceModules['ext.scratchBlocks'] = array(
     'scripts' => array(
-        'ScratchBlocks/src/scratchblocks.js',
-		'scratchblocks/src/translations.js',
+        'scratchblocks/src/scratchblocks.js',
+        'scratchblocks/src/translations.js',
         'run_scratchblocks.js',
     ),
 

--- a/ScratchblockHooks.php
+++ b/ScratchblockHooks.php
@@ -14,16 +14,14 @@ class ScratchblockHook {
 		global $wgOut;
 		$wgOut->addModules('ext.scratchBlocks');
 	}
-	
+
+	// Output HTML for <scratchblocks> tag
 	public static function sbRenderTag ($input, array $args, Parser $parser, PPFrame $frame) {
-		//throw new Exception("234");
 		return '<pre class="blocks">' . htmlspecialchars($input) . '</pre>';
 	}
 
 	// Output HTML for inline <sb> tag
 	public static function sbRenderInlineTag ($input, array $args, Parser $parser, PPFrame $frame) {
-		//throw new Exception("what");
-		//throw new Exception("2345");
 		return '<code class="blocks">' . htmlspecialchars($input) . '</code>';
 	}
 }

--- a/extension.json
+++ b/extension.json
@@ -18,7 +18,7 @@
 	"ResourceModules": {
 		"ext.scratchBlocks": {
 			"scripts": [
-				"ScratchBlocks/src/scratchblocks.js",
+				"scratchblocks/src/scratchblocks.js",
 				"scratchblocks/src/translations.js",
 				"run_scratchblocks.js"
 			],


### PR DESCRIPTION
Wrong case prevented JS from loading from submodule in Linux

Hi tjvr/wiki-scratchblocks#6
